### PR TITLE
Fix bug reading from `panda.can_recv()`

### DIFF
--- a/extract_keys.py
+++ b/extract_keys.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     with open(f'data_{start:08x}_{end:08x}.bin', 'wb') as f:
         with tqdm(total=end-start) as pbar:
             while start < end:
-                for addr, _, data, bus in panda.can_recv():
+                for addr, data, bus in panda.can_recv():
                     if bus != BUS:
                         continue
 


### PR DESCRIPTION
The `busTime` field was deprecated from the return of this function call
See: https://github.com/commaai/panda/commit/8c3bb0151e8907ade344ccb293d58cd543e28baa

And validated with my own testing.