### PR TITLE
UDS: Update import to align with upstream changes

### DIFF
--- a/extract_keys.py
+++ b/extract_keys.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from panda import Panda
 try:
     # If openpilot is installed
-    from panda.python.uds import UdsClient, ACCESS_TYPE, SESSION_TYPE, DATA_IDENTIFIER_TYPE, SERVICE_TYPE, ROUTINE_CONTROL_TYPE, NegativeResponseError
+    from opendbc.car.uds import UdsClient, ACCESS_TYPE, SESSION_TYPE, DATA_IDENTIFIER_TYPE, SERVICE_TYPE, ROUTINE_CONTROL_TYPE, NegativeResponseError
 except ImportError:
     # If installed from pip
     from panda.uds import UdsClient, ACCESS_TYPE, SESSION_TYPE, DATA_IDENTIFIER_TYPE, SERVICE_TYPE, ROUTINE_CONTROL_TYPE, NegativeResponseError

--- a/extract_keys.py
+++ b/extract_keys.py
@@ -9,12 +9,7 @@ from Crypto.Cipher import AES
 from tqdm import tqdm
 
 from panda import Panda
-try:
-    # If openpilot is installed
-    from opendbc.car.uds import UdsClient, ACCESS_TYPE, SESSION_TYPE, DATA_IDENTIFIER_TYPE, SERVICE_TYPE, ROUTINE_CONTROL_TYPE, NegativeResponseError
-except ImportError:
-    # If installed from pip
-    from panda.uds import UdsClient, ACCESS_TYPE, SESSION_TYPE, DATA_IDENTIFIER_TYPE, SERVICE_TYPE, ROUTINE_CONTROL_TYPE, NegativeResponseError
+from opendbc.car.uds import UdsClient, ACCESS_TYPE, SESSION_TYPE, DATA_IDENTIFIER_TYPE, SERVICE_TYPE, ROUTINE_CONTROL_TYPE, NegativeResponseError
 
 ADDR = 0x7a1
 DEBUG = False


### PR DESCRIPTION
**Description**

- `uds.py` has been migrated from `panda` to `opendbc`, which means this script will currently break when running on branches using the latest upstream code.
- This change updates the import paths to maintain compatibility with the updated upstream structure. It also removes the fallback mechanism for handling different installation environments, simplifying the script's dependencies.
- Ensures that the script works seamlessly with the latest code and avoids potential breakages when used alongside future upstream changes.

**Upstream PRs**
- https://github.com/commaai/openpilot/pull/34374
- https://github.com/commaai/opendbc/pull/1598
- https://github.com/commaai/panda/pull/2121